### PR TITLE
Fixed property visibility.

### DIFF
--- a/lib/avro/datum.php
+++ b/lib/avro/datum.php
@@ -76,7 +76,7 @@ class AvroIODatumWriter
    * Schema used by this instance to write Avro data.
    * @var AvroSchema
    */
-  private $writers_schema;
+  public $writers_schema;
 
   /**
    * @param AvroSchema $writers_schema


### PR DESCRIPTION
As seen [here](https://github.com/researchgate/avro-php/blob/ff8841585ad76acbff5b673bafd5b70f35d311cb/lib/avro/data_file.php#L451) this property has to be public