### PR TITLE
Added support for PHP 8.2

### DIFF
--- a/lib/avro/schema.php
+++ b/lib/avro/schema.php
@@ -57,7 +57,7 @@ class AvroSchemaParseException extends AvroException {};
 /**
  * @package Avro
  */
-class AvroSchema
+class AvroSchema extends \stdCLass
 {
   /**
    * @var int lower bound of integer values: -(1 << 31)
@@ -905,7 +905,7 @@ class AvroNamedSchema extends AvroSchema
 /**
  * @package Avro
  */
-class AvroName
+class AvroName extends \stdCLass
 {
   /**
    * @var string character used to separate names comprising the fullname
@@ -1055,7 +1055,7 @@ class AvroName
  *
  * @package Avro
  */
-class AvroNamedSchemata
+class AvroNamedSchemata extends \stdCLass
 {
   /**
    * @var AvroNamedSchema[]


### PR DESCRIPTION
Added PHP 8.2+ support using suggestions from this doc and suggested way using inheritance from `\stdClass`
- https://php.watch/versions/8.2/dynamic-properties-deprecated#stdClass
