### PR TITLE
ci(php): Remove PHP 7.3 checks, add PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
A PR on adding PHP 8.2 support reminded me that we're currently not checking for PHP 8.2 compatibility.

Equally, PHP 7.3 is long deprecated, so we should avoid testing for it.